### PR TITLE
Use forever programmatically

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -16,5 +16,6 @@
     "download": { "reply": "Please only download from the official *Citra* website, as downloading from other sources is not supported here. <https://citra-emu.org/download/>"},
     "legal": { "reply": "*Citra* is legal, we don't support illegal activities. Dumping your purchased games and system files from your 3DS is legal. Downloading them is not."},
     "building": { "reply": "Please refer to our building guides.\nWindows: <https://citra-emu.org/wiki/Building-for-Windows> \nmacOS: <https://citra-emu.org/wiki/Building-for-macOS> \nLinux: <https://citra-emu.org/wiki/Building-for-Linux>"}
-  }
+  },
+  "production": true
 }

--- a/logging.js
+++ b/logging.js
@@ -1,8 +1,9 @@
-var config = require('config');
 var winston = require('winston');
 var logdna = require('logdna');
 var ip = require('ip');
 var os = require("os");
+
+var config = require('./config.json');
 
 winston.emitErrs = true;
 var logger = new winston.Logger({
@@ -19,7 +20,7 @@ var logger = new winston.Logger({
     exitOnError: false
 });
 
-if (process.env.NODE_ENV == 'production') {
+if (config.production == true) {
     // Setup logging for LogDNA cloud logging.
     logger.add(winston.transports.Logdna, {
         level: 'info',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Citra bot for Discord",
   "author": "chris062689 <chris062689@gmail.com>",
   "scripts": {
-    "start": "node server.js"
+    "start": "node start.js"
   },
   "preferGlobal": true,
   "private": true,
@@ -17,6 +17,7 @@
     "ip": "^1.1.5",
     "logdna": "^1.2.3",
     "request": "^2.79.0",
-    "winston": "^2.3.0"
+    "winston": "^2.3.0",
+    "forever-monitor": "^1.5.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
 var discord = require('discord.js');
 var fs = require('fs');
 var path = require('path');
-var config = require('config');
 
+var config = require('./config.json');
 var logger = require('./logging.js');
 var app = require('./app.js');
 var data = require('./data.js');

--- a/start.js
+++ b/start.js
@@ -1,0 +1,8 @@
+var forever = require('forever-monitor');
+var config = require('config')
+
+var child = new (forever.Monitor)('server.js', {
+  silent: !config.production
+});
+
+child.start(true);

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-NODE_ENV=production forever start server.js


### PR DESCRIPTION
I've replaced the `start.sh` script with `start.js`, changed the `package.json` to reflect this, and added `forever-monitor` (a subset of `forever` that does not have CLI capabilities) as a dependency.

This will allow running and testing the bot to work out of the box anywhere `npm run` is supported, as I mentioned in #6.