### PR TITLE
Implement loading responses from data/

### DIFF
--- a/env.json
+++ b/env.json
@@ -19,5 +19,9 @@
     "CANARY_WEBHOOK_URL": {
       "required": false,
       "description": "The URL for the webhook to trigger canary builds."
+    },
+    "DATA_CUSTOM_RESPONSES": {
+      "required": false,
+      "description": "Whether or not to load responses.js from the data directory."
     }
   }

--- a/src/data.js
+++ b/src/data.js
@@ -22,6 +22,17 @@ function readBans () {
   });
 }
 
+function readCustomResponses()
+{
+  // Load the responses file into the responses variable.
+  fs.readFile('data/responses.json', 'utf8', function (err, data) {
+    if (err && err.code === 'ENOENT') { return; }
+    if (err) { logger.error(err); }
+    state.responses = JSON.parse(data);
+    logger.debug('Loaded responses file.');
+  });
+}
+
 function flushWarnings () {
   var warningsJson = JSON.stringify(state.warnings, null, 4);
   if (!fs.existsSync('./data/')) fs.mkdirSync('data');
@@ -38,4 +49,4 @@ function flushBans () {
   });
 }
 
-module.exports = { readWarnings: readWarnings, readBans: readBans, flushWarnings: flushWarnings, flushBans: flushBans };
+module.exports = { readWarnings: readWarnings, readBans: readBans, readCustomResponses: readCustomResponses, flushWarnings: flushWarnings, flushBans: flushBans };

--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,7 @@ const logger = require('./logging.js');
 const state = require('./state.js');
 const data = require('./data.js');
 
-var responses = require('./responses.json');
+state.responses = require('./responses.json');
 
 var cachedModules = [];
 var cachedTriggers = [];
@@ -57,11 +57,11 @@ schedule.scheduleJob({ hour: 3, minute: 30 }, function () {
 client.on('message', message => {
   if (message.author.bot && message.content.startsWith('.ban') === false) { return; }
 
-  if (message.guild == null && responses.pmReply) {
+  if (message.guild == null && state.responses.pmReply) {
     // We want to log PM attempts.
     logger.info(`${message.author.username} ${message.author} [PM]: ${message.content}`);
     state.logChannel.sendMessage(`${message.author} [PM]: ${message.content}`);
-    message.reply(responses.pmReply);
+    message.reply(state.responses.pmReply);
     return;
   }
 
@@ -75,7 +75,7 @@ client.on('message', message => {
     let cachedModule = cachedModules[`${cmd}.js`];
     let cachedModuleType = 'Command';
     // Check by the quotes in the configuration.
-    if (cachedModule == null) { cachedModule = responses.quotes[cmd]; cachedModuleType = 'Quote'; }
+    if (cachedModule == null) { cachedModule = state.responses.quotes[cmd]; cachedModuleType = 'Quote'; }
 
     if (cachedModule) {
       // Check access permissions.
@@ -156,6 +156,12 @@ fs.readdirSync('./src/triggers/').forEach(function (file) {
 
 data.readWarnings();
 data.readBans();
+
+// Load custom responses
+if (process.env.DATA_CUSTOM_RESPONSES)
+{
+    data.readCustomResponses();
+}
 
 client.login(process.env.DISCORD_LOGIN_TOKEN);
 logger.info('Startup completed. Established connection to Discord.');

--- a/src/state.js
+++ b/src/state.js
@@ -3,6 +3,7 @@ var State = function () {
   this.guild = null;
   this.logChannel = null;
   this.warnings = [];
+  this.responses = null;
   this.bans = [];
   this.stats = {
     joins: 0,


### PR DESCRIPTION
*New environment variables*
- `DATA_CUSTOM_RESPONSES`: Whether or not to load responses.js from the data directory.

This makes the discord-bot load its `responses.json` from the `data` instead of the `src` directory.