### PR TITLE
server.js: Add the functionality to auto-moderate media in a channel

### DIFF
--- a/env.json
+++ b/env.json
@@ -17,6 +17,9 @@
     "DISCORD_LOG_CHANNEL": {
       "description": "The unique ID for the channel the bot will output logs to."
     },
+    "DISCORD_MEDIA_CHANNEL": {
+      "description": "The unique ID for the channel the bot will moderate images in."
+    },
     "DISCORD_RULES_CHANNEL": {
       "description": "The unique ID for the channel that the bot will manage rules from."
     },


### PR DESCRIPTION
This makes it possible to auto-delete text-messages, sent in a channel meant for images and other media.

Currently, this feature uses the very naive approach of storing every user ID in a map, along with a boolean that determines if their last message was an "allowed" post or not. If the last post was allowed, they are able to send one text message after it.

I'm not very used to working with Javascript, so as always, any ideas to improve the code are very welcome.