### PR TITLE
Add logging for message edits/deletions

### DIFF
--- a/env.json
+++ b/env.json
@@ -17,6 +17,9 @@
     "DISCORD_LOG_CHANNEL": {
       "description": "The unique ID for the channel the bot will output logs to."
     },
+    "DISCORD_MSGLOG_CHANNEL": {
+      "description": "The unique ID for the channel the bot will output message logs to."
+    },
     "DISCORD_MEDIA_CHANNEL": {
       "description": "The unique ID for the channel the bot will moderate images in."
     },

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,11 @@ function findArray (haystack, arr) {
   });
 }
 
+function IsIgnoredChannel (channelName) {
+  const IgnoredChannels = ['welcome', 'announcements', 'media'];
+  return IgnoredChannels.includes(channelName);
+}
+
 client.on('ready', () => {
   // Initialize app channels.
   state.logChannel = client.channels.get(process.env.DISCORD_LOG_CHANNEL);
@@ -67,34 +72,38 @@ client.on('guildMemberAdd', (member) => {
 });
 
 client.on('messageDelete', message => {
-  if (Boolean(message.content) && !message.content.startsWith('.')) {
-    const deletionEmbed = new discord.RichEmbed()
-      .setAuthor(message.author.tag, message.author.displayAvatarURL)
-      .setDescription(`Message deleted in ${message.channel}`)
-      .addField('Content', message.cleanContent, false)
-      .setTimestamp()
-      .setColor('RED');
+  if (IsIgnoredChannel(message.channel.name) == false) {
+    if (message.content && message.content.startsWith('.') == false && message.author.bot == false) {
+      const deletionEmbed = new discord.RichEmbed()
+        .setAuthor(message.author.tag, message.author.displayAvatarURL)
+        .setDescription(`Message deleted in ${message.channel}`)
+        .addField('Content', message.cleanContent, false)
+        .setTimestamp()
+        .setColor('RED');
 
-    state.msglogChannel.send(deletionEmbed);
-    logger.info(`${message.author.username} ${message.author} deleted message: ${message.cleanContent}.`);
+      state.msglogChannel.send(deletionEmbed);
+      logger.info(`${message.author.username} ${message.author} deleted message: ${message.cleanContent}.`);
+    }
   }
 });
 
 client.on('messageUpdate', (oldMessage, newMessage) => {
-  const oldM = oldMessage.cleanContent;
-  const newM = newMessage.cleanContent;
+  if (IsIgnoredChannel(oldMessage.channel.name) == false) {
+    const oldM = oldMessage.cleanContent;
+    const newM = newMessage.cleanContent;
 
-  if (Boolean(oldM) && Boolean(newM)) {
-    const editedEmbed = new discord.RichEmbed()
-      .setAuthor(oldMessage.author.tag, oldMessage.author.displayAvatarURL)
-      .setDescription(`Message edited in ${oldMessage.channel} [Jump To Message](${newMessage.url})`)
-      .addField('Before', oldM, false)
-      .addField('After', newM, false)
-      .setTimestamp()
-      .setColor('GREEN');
+    if (oldM && newM) {
+      const editedEmbed = new discord.RichEmbed()
+        .setAuthor(oldMessage.author.tag, oldMessage.author.displayAvatarURL)
+        .setDescription(`Message edited in ${oldMessage.channel} [Jump To Message](${newMessage.url})`)
+        .addField('Before', oldM, false)
+        .addField('After', newM, false)
+        .setTimestamp()
+        .setColor('GREEN');
 
-    state.msglogChannel.send(editedEmbed);
-    logger.info(`${oldMessage.author.username} ${oldMessage.author} edited message from: ${oldM} to: ${newM}.`);
+      state.msglogChannel.send(editedEmbed);
+      logger.info(`${oldMessage.author.username} ${oldMessage.author} edited message from: ${oldM} to: ${newM}.`);
+    }
   }
 });
 

--- a/src/server.js
+++ b/src/server.js
@@ -38,6 +38,7 @@ function findArray (haystack, arr) {
 client.on('ready', () => {
   // Initialize app channels.
   state.logChannel = client.channels.get(process.env.DISCORD_LOG_CHANNEL);
+  state.msglogChannel = client.channels.get(process.env.DISCORD_MSGLOG_CHANNEL);
   state.guild = state.logChannel.guild;
 
   logger.info('Bot is now online and connected to server.');
@@ -63,6 +64,38 @@ client.on('reconnecting', () => {
 
 client.on('guildMemberAdd', (member) => {
   member.addRole(process.env.DISCORD_RULES_ROLE);
+});
+
+client.on('messageDelete', message => {
+  if (Boolean(message.content) && !message.content.startsWith('.')) {
+    const deletionEmbed = new discord.RichEmbed()
+      .setAuthor(message.author.tag, message.author.displayAvatarURL)
+      .setDescription(`Message deleted in ${message.channel}`)
+      .addField('Content', message.cleanContent, false)
+      .setTimestamp()
+      .setColor('RED');
+
+    state.msglogChannel.send(deletionEmbed);
+    logger.info(`${message.author.username} ${message.author} deleted message: ${message.cleanContent}.`);
+  }
+});
+
+client.on('messageUpdate', (oldMessage, newMessage) => {
+  const oldM = oldMessage.cleanContent;
+  const newM = newMessage.cleanContent;
+
+  if (Boolean(oldM) && Boolean(newM)) {
+    const editedEmbed = new discord.RichEmbed()
+      .setAuthor(oldMessage.author.tag, oldMessage.author.displayAvatarURL)
+      .setDescription(`Message edited in ${oldMessage.channel} [Jump To Message](${newMessage.url})`)
+      .addField('Before', oldM, false)
+      .addField('After', newM, false)
+      .setTimestamp()
+      .setColor('GREEN');
+
+    state.msglogChannel.send(editedEmbed);
+    logger.info(`${oldMessage.author.username} ${oldMessage.author} edited message from: ${oldM} to: ${newM}.`);
+  }
 });
 
 client.on('message', message => {

--- a/src/state.js
+++ b/src/state.js
@@ -2,6 +2,7 @@
 const State = function () {
   this.guild = null;
   this.logChannel = null;
+  this.msglogChannel = null;
   this.warnings = [];
   this.responses = null;
   this.bans = [];


### PR DESCRIPTION
[**Update 1**] - Changed confusing naming & used `const` instead of `let`
[**Update 2**] - Make RichEmbeds compact.
[**Update 3**] - Addressed reviews.
[**Update 4**] - Added channel exceptions.
***

* Added logging for message edits and message deletions.
**Note:** Due to the limitations of Discord API, it is currently not possible to log, ***who*** deleted a message (mod or user or bot). Hence, we only log the deleted message. 
* Bot outputs info in neat RichEmbeds.
* Uses an env variable - `DISCORD_MSGLOG_CHANNEL` and adds a variable `msglogChannel` in `state.js` as well.  A new channel for this should be created. Then, the ID is to be defined in the `env.json` and the docker image needs to be updated.
