### PR TITLE
Log UserID for moderation

### DIFF
--- a/env.json
+++ b/env.json
@@ -20,6 +20,9 @@
     "DISCORD_MSGLOG_CHANNEL": {
       "description": "The unique ID for the channel the bot will output message logs to."
     },
+    "DISCORD_USERLOG_CHANNEL": {
+      "description": "The unique ID for the channel the bot will output user join logs to."
+    },
     "DISCORD_MEDIA_CHANNEL": {
       "description": "The unique ID for the channel the bot will moderate images in."
     },

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -16,7 +16,7 @@ exports.command = function (message: discord.Message) {
     }
 
     logger.info(`${message.author.username} ${message.author} has warned ${user.username} ${user} [${count} + 1].`);
-    state.logChannel.send(`${message.author.toString()} has warned ${user.toString()} [${count} + 1].`);
+    state.logChannel.send(`${message.author.toString()} has warned ${user.toString()} [${user}] [${count} + 1].`);
 
     state.warnings.push(new UserWarning(user.id, user.username, message.author.id, message.author.username, count, silent));
     data.flushWarnings();

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,15 +45,18 @@ function IsIgnoredCategory(categoryName: string) {
 
 client.on('ready', async () => {
   // Initialize app channels.
-  if (!process.env.DISCORD_LOG_CHANNEL || !process.env.DISCORD_MSGLOG_CHANNEL) {
-    throw new Error('DISCORD_LOG_CHANNEL or DISCORD_MSGLOG_CHANNEL not defined.');
+  if (!process.env.DISCORD_LOG_CHANNEL || !process.env.DISCORD_MSGLOG_CHANNEL || !process.env.DISCORD_USERLOG_CHANNEL) {
+    throw new Error('DISCORD_LOG_CHANNEL or DISCORD_MSGLOG_CHANNEL or DISCORD_USERLOG_CHANNEL not defined.');
   }
   let logChannel = await client.channels.fetch(process.env.DISCORD_LOG_CHANNEL) as discord.TextChannel;
   let msglogChannel = await client.channels.fetch(process.env.DISCORD_MSGLOG_CHANNEL) as discord.TextChannel;
+  let userlogChannel = await client.channels.fetch(process.env.DISCORD_USERLOG_CHANNEL) as discord.TextChannel;
   if (!logChannel.send) throw new Error('DISCORD_LOG_CHANNEL is not a text channel!');
   if (!msglogChannel.send) throw new Error('DISCORD_MSGLOG_CHANNEL is not a text channel!');
+  if (!userlogChannel.send) throw new Error('DISCORD_USERLOG_CHANNEL is not a text channel!');
   state.logChannel = logChannel;
   state.msglogChannel = msglogChannel;
+  state.userlogChannel = userlogChannel;
 
   logger.info('Bot is now online and connected to server.');
 });
@@ -162,6 +165,7 @@ client.on('message', message => {
     if (message.content.toLowerCase().includes(rulesTrigger)) {
       // We want to remove the 'Unauthorized' role from them once they agree to the rules.
       logger.verbose(`${message.author.username} ${message.author} has accepted the rules, removing role ${process.env.DISCORD_RULES_ROLE}.`);
+      state.userlogChannel.send(`${message.author.toString()} has accepted the rules, their ID is ${message.author}`);
       message.member?.roles.remove(rluesRole, 'Accepted the rules.');
     }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,6 +7,7 @@ import discord = require('discord.js');
 class State {
   logChannel: discord.TextChannel | discord.DMChannel;
   msglogChannel: discord.TextChannel | discord.DMChannel;
+  userlogChannel: discord.TextChannel | discord.DMChannel;
   warnings: UserWarning[];
   responses: IResponses;
   bans: UserBan[];
@@ -18,6 +19,7 @@ class State {
   constructor () {
     this.logChannel;
     this.msglogChannel;
+    this.userlogChannel;
     this.warnings = [];
     this.responses;
     this.bans = [];


### PR DESCRIPTION
[DO NOT MERGE] [NOT TESTED]
***

This PR defines a new `ENV` variable - `DISCORD_USERLOG_CHANNEL` - which is the ID of the text channel where discord logs `User joined the server` messages. With these changes, we can disable those messages and instead just log the IDs of users who pass our initial authentication check.

Also, we now log user IDs with warnings to improve the ease of moderation.